### PR TITLE
Improve double spend error logging.

### DIFF
--- a/validate.go
+++ b/validate.go
@@ -701,8 +701,7 @@ func CheckTransactionInputs(tx *btcutil.Tx, txHeight int64, txStore TxStore) (in
 		}
 		if originTx.Spent[originTxIndex] {
 			str := fmt.Sprintf("transaction %v tried to double "+
-				"spend coins from transaction %v", txHash,
-				txInHash)
+				"spend output %v", txHash, txIn.PreviousOutPoint)
 			return 0, ruleError(ErrDoubleSpend, str)
 		}
 


### PR DESCRIPTION
The error message now includes both the previous tx hash and output
index, rather than simply the transaction with the already spent
output.